### PR TITLE
Pressing left arrow key or J invokes get_selected and returns (None, -…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,20 @@ list in the terminal. See it in action:
 * `title`: (optional) a title above options list
 * `indicator`: (optional) custom the selection indicator, defaults to *
 * `default_index`: (optional) set this if the default selected option is not the first one
+
+#### Register custom handlers
+
+sometimes you may need to register custom handlers to specific keys, you can use the `register_custom_handler` API:
+
+    >>> from pick import Picker
+    >>> title, options = 'Title', ['Option1', 'Option2']
+    >>> picker = Picker(options, title)
+    >>> def go_back(picker):
+    ...     return None, -1
+    >>> picker.register_custom_handler(ord('h'),  go_back)
+    >>> option, index = picker.start()
+
+* the custom handler will be called with the `picker` instance as it's parameter.
+* the custom handler should either return a two element tuple, or None.
+* if None is returned, the picker would continue to run, otherwise the picker will stop and return the tuple.
+

--- a/example/custom.py
+++ b/example/custom.py
@@ -1,0 +1,17 @@
+#-*-coding:utf-8-*-
+
+from __future__ import print_function
+
+import curses
+from pick import Picker
+
+def go_back(picker):
+    return (None, -1)
+
+title = 'Please choose your favorite programming language: '
+options = ['Java', 'JavaScript', 'Python', 'PHP', 'C++', 'Erlang', 'Haskell']
+
+picker = Picker(options, title)
+picker.register_custom_handler(curses.KEY_LEFT, go_back)
+option, index = picker.start()
+print(option, index)

--- a/pick/__init__.py
+++ b/pick/__init__.py
@@ -33,6 +33,10 @@ class Picker(object):
             raise ValueError('default_index should be less than the length of options')
 
         self.index = default_index
+        self.custom_handlers = {}
+
+    def register_custom_handler(self, key, func):
+        self.custom_handlers[key] = func
 
     def move_up(self):
         self.index -= 1
@@ -110,6 +114,10 @@ class Picker(object):
                 self.move_down()
             elif c in KEYS_ENTER:
                 return self.get_selected()
+            elif c in self.custom_handlers:
+                ret = self.custom_handlers[c](self)
+                if ret:
+                    return ret
 
     def config_curses(self):
         # use the default colors of the terminal


### PR DESCRIPTION
@wong2 

Hey dude! `pick` is awesome, I just used it to write a library for building and running a **Questionnaire**, and `pick`'s API made it easy.

In writing `questionnaire`, I needed to be able to respond to **back** events, so I made the following change to pick:

If `can_go_back=True` is passed when calling `pick` or instantiating a `Picker`, then pressing the left arrow key or `j` invokes `go_back` and returns a special `(None, -1)` tuple, so that clients can respond to 'back' events.

By default `can_go_back=False`, which means this behavior is opt-in. I think it's a good addition to pick's functionality, and it's implemented in a way that won't change `pick`'s behavior for existing clients. What do you think?