### PR TITLE
Add support for options mapping 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ list in the terminal. See it in action:
     >>> print index
 
 **outputs**
- 
-    >>> C++ 
+
+    >>> C++
     >>> 4
 
 **pick** multiselect example:
@@ -50,10 +50,11 @@ list in the terminal. See it in action:
 * `default_index`: (optional) set this if the default selected option is not the first one
 * `multi_select`: (optional), if set to True its possible to select multiple items by hitting SPACE
 * `min_selection_count`: (optional) for multi select feature to dictate a minimum of selected items before continuing
+* `options_map`: (optional) a mapping function to pass each option through before displaying
 
 #### Register custom handlers
 
-sometimes you may need to register custom handlers to specific keys, you can use the `register_custom_handler` API:
+sometimes you may need to register custom handlers for specific keyboard keys, you can use the `register_custom_handler` API:
 
     >>> from pick import Picker
     >>> title, options = 'Title', ['Option1', 'Option2']
@@ -67,3 +68,32 @@ sometimes you may need to register custom handlers to specific keys, you can use
 * the custom handler should either return a two element tuple, or None.
 * if None is returned, the picker would continue to run, otherwise the picker will stop and return the tuple.
 
+#### Options Map
+
+If your options are not in a format that you want displayed (such as a dictionary), you can pass in a mapping function which each option will be run through. The return value of the function will be displayed.
+
+* the selected option returned will be the original value and not the displayed return result from the `options_map` function.
+
+**pick** options map example:
+
+    >>> from pick import pick
+
+    >>> title = 'Please choose an option: '
+    >>> options = [{'label': 'option1'}, {'label': 'option2'}, {'label': 'option3'}]
+
+    >>> def get_label(option): return option.get('label')
+
+    >>> selected = pick(options, title, indicator='*', options_map=get_label)
+    >>> print selected
+
+**displays**
+
+    Please choose an option:
+
+    * option1
+      option2
+      option3
+
+**outputs**
+
+    >>> ({ 'label': 'option1' }, 0)

--- a/example/options_map.py
+++ b/example/options_map.py
@@ -1,0 +1,20 @@
+#-*-coding:utf-8-*-
+
+from __future__ import print_function
+
+from pick import pick
+
+title = 'Please choose your favorite fruit: '
+options = [
+    { 'name': 'Apples', 'grow_on': 'trees' },
+    { 'name': 'Oranges', 'grow_on': 'trees' },
+    { 'name': 'Strawberries', 'grow_on': 'vines' },
+    { 'name': 'Grapes', 'grow_on': 'vines' },
+]
+
+def get_description_for_display(option):
+    # format the option data for display
+    return '{0} (grow on {1})'.format(option.get('name'), option.get('grow_on'))
+
+option, index = pick(options, title, indicator='=>', options_map=get_description_for_display)
+print(option, index)

--- a/pick/__init__.py
+++ b/pick/__init__.py
@@ -18,9 +18,10 @@ class Picker(object):
     :param multi_select: (optional) if true its possible to select multiple values by hitting SPACE, defaults to False
     :param indicator: (optional) custom the selection indicator
     :param default_index: (optional) set this if the default selected option is not the first one
+    :param options_map: (optional) a mapping function to pass each option through before displaying
     """
 
-    def __init__(self, options, title=None, indicator='*', default_index=0, multi_select=False, min_selection_count=0):
+    def __init__(self, options, title=None, indicator='*', default_index=0, multi_select=False, min_selection_count=0, options_map=None):
 
         if len(options) == 0:
             raise ValueError('options should not be an empty list')
@@ -30,6 +31,7 @@ class Picker(object):
         self.indicator = indicator
         self.multi_select = multi_select
         self.min_selection_count = min_selection_count
+        self.options_map = options_map
         self.all_selected = []
 
         if default_index >= len(options):
@@ -37,6 +39,9 @@ class Picker(object):
 
         if multi_select and min_selection_count > len(options):
             raise ValueError('min_selection_count is bigger than the available options, you will not be able to make any selection')
+
+        if options_map is not None and not callable(options_map):
+            raise ValueError('options_map must be a callable function')
 
         self.index = default_index
         self.custom_handlers = {}
@@ -81,6 +86,10 @@ class Picker(object):
     def get_option_lines(self):
         lines = []
         for index, option in enumerate(self.options):
+            # pass the option through the options map of one was passed in
+            if self.options_map:
+                option = self.options_map(option)
+
             if index == self.index:
                 prefix = self.indicator
             else:
@@ -168,7 +177,7 @@ class Picker(object):
         return curses.wrapper(self._start)
 
 
-def pick(options, title=None, indicator='*', default_index=0, multi_select=False, min_selection_count=0):
+def pick(options, title=None, indicator='*', default_index=0, multi_select=False, min_selection_count=0, options_map=None):
     """Construct and start a :class:`Picker <Picker>`.
 
     Usage::
@@ -178,5 +187,5 @@ def pick(options, title=None, indicator='*', default_index=0, multi_select=False
       >>> options = ['option1', 'option2', 'option3']
       >>> option, index = pick(options, title)
     """
-    picker = Picker(options, title, indicator, default_index, multi_select, min_selection_count)
+    picker = Picker(options, title, indicator, default_index, multi_select, min_selection_count, options_map)
     return picker.start()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def fread(fname):
 
 setup(
     name='pick',
-    version='0.6.3',
+    version='0.6.4',
     description='pick an option in the terminal with a simple GUI',
     long_description=fread('README.md'),
     keywords='terminal gui',

--- a/tests/test_pick.py
+++ b/tests/test_pick.py
@@ -47,6 +47,17 @@ class TestPick(unittest.TestCase):
         picker.mark_index()
         assert picker.get_selected() == [('option1', 0), ('option2', 1)]
 
+    def test_options_map(self):
+        title = 'Please choose an option: '
+        options = [{'label': 'option1'}, {'label': 'option2'}, {'label': 'option3'}]
+
+        def get_label(option): return option.get('label')
+
+        picker = Picker(options, title, indicator='*', options_map=get_label)
+        lines, current_line = picker.get_lines()
+        assert lines == [title, '', '* option1', '  option2', '  option3']
+        assert picker.get_selected() == ({ 'label': 'option1' }, 0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I added a new optional parameter to the constructor to allow a user to pass in a custom options mapping function. Each provided option will be passed through the `options_map` and the returned value is what will be displayed. The selected value that is returned is the original option. 

This way, users can pass in a list of dictionaries and format each for display but still get back the selected dictionary.

I added a new test and all tests passed. Additionally, I incremented the least significant digit of the version.