### PR TITLE
Add configurable multiselect colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __pycache__/
 # due to using tox and pytest
 .tox
 .cache
+
+# mac
+.DS_STORE

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ list in the terminal. See it in action:
     >>> print index
 
 **outputs**
- 
-    >>> C++ 
+
+    >>> C++
     >>> 4
 
 **pick** multiselect example:
@@ -50,10 +50,11 @@ list in the terminal. See it in action:
 * `default_index`: (optional) set this if the default selected option is not the first one
 * `multi_select`: (optional), if set to True its possible to select multiple items by hitting SPACE
 * `min_selection_count`: (optional) for multi select feature to dictate a minimum of selected items before continuing
+* `options_map`: (optional) a mapping function to pass each option through before displaying
 
 #### Register custom handlers
 
-sometimes you may need to register custom handlers to specific keys, you can use the `register_custom_handler` API:
+sometimes you may need to register custom handlers for specific keyboard keys, you can use the `register_custom_handler` API:
 
     >>> from pick import Picker
     >>> title, options = 'Title', ['Option1', 'Option2']
@@ -67,3 +68,32 @@ sometimes you may need to register custom handlers to specific keys, you can use
 * the custom handler should either return a two element tuple, or None.
 * if None is returned, the picker would continue to run, otherwise the picker will stop and return the tuple.
 
+#### Options Map
+
+If your options are not in a format that you want displayed (such as a dictionary), you can pass in a mapping function which each option will be run through. The return value of the function will be displayed.
+
+* the selected option returned will be the original value and not the displayed return result from the `options_map` function.
+
+**pick** options map example:
+
+    >>> from pick import pick
+
+    >>> title = 'Please choose an option: '
+    >>> options = [{'label': 'option1'}, {'label': 'option2'}, {'label': 'option3'}]
+
+    >>> def get_label(option): return option.get('label')
+
+    >>> selected = pick(options, title, indicator='*', options_map=get_label)
+    >>> print selected
+
+**displays**
+
+    Please choose an option:
+
+    * option1
+      option2
+      option3
+
+**outputs**
+
+    >>> ({ 'label': 'option1' }, 0)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ list in the terminal. See it in action:
 * `multi_select`: (optional), if set to True its possible to select multiple items by hitting SPACE
 * `min_selection_count`: (optional) for multi select feature to dictate a minimum of selected items before continuing
 * `options_map`: (optional) a mapping function to pass each option through before displaying
+* `multi_select_foreground_color`: (optional) forground color of a selected option within multi_select mode
+* `multi_select_background_color`: (optional) background color of a selected option within multi_select mode
 
 #### Register custom handlers
 
@@ -97,3 +99,20 @@ If your options are not in a format that you want displayed (such as a dictionar
 **outputs**
 
     >>> ({ 'label': 'option1' }, 0)
+
+### Multi-Select Colors
+
+Using the `multi_select_foreground_color` and `multi_select_background_color` options, you can specify the colors that are used when a user selects an option as part of the multi-select mode.
+
+The accepted colors are any of the [curses](https://docs.python.org/2/library/curses.html) predefined color constants, passed as a string:
+```
+'COLOR_BLACK'
+'COLOR_BLUE'
+'COLOR_CYAN'
+'COLOR_GREEN'
+'COLOR_MAGENTA'
+'COLOR_RED'
+'COLOR_WHITE'
+'COLOR_YELLOW'
+```
+

--- a/example/multi_select.py
+++ b/example/multi_select.py
@@ -1,0 +1,10 @@
+#-*-coding:utf-8-*-
+
+from __future__ import print_function
+
+from pick import pick
+
+title = 'Please choose your favorite programming language: '
+options = ['Java', 'JavaScript', 'Python', 'PHP', 'C++', 'Erlang', 'Haskell']
+selected_options = pick(options, title, indicator='=>', multi_select=True, multi_select_foreground_color='COLOR_BLUE')
+print(selected_options)

--- a/example/options_map.py
+++ b/example/options_map.py
@@ -1,0 +1,20 @@
+#-*-coding:utf-8-*-
+
+from __future__ import print_function
+
+from pick import pick
+
+title = 'Please choose your favorite fruit: '
+options = [
+    { 'name': 'Apples', 'grow_on': 'trees' },
+    { 'name': 'Oranges', 'grow_on': 'trees' },
+    { 'name': 'Strawberries', 'grow_on': 'vines' },
+    { 'name': 'Grapes', 'grow_on': 'vines' },
+]
+
+def get_description_for_display(option):
+    # format the option data for display
+    return '{0} (grow on {1})'.format(option.get('name'), option.get('grow_on'))
+
+option, index = pick(options, title, indicator='=>', options_map=get_description_for_display)
+print(option, index)

--- a/pick/__init__.py
+++ b/pick/__init__.py
@@ -10,6 +10,18 @@ KEYS_UP = (curses.KEY_UP, ord('k'))
 KEYS_DOWN = (curses.KEY_DOWN, ord('j'))
 KEYS_SELECT = (curses.KEY_RIGHT, ord(' '))
 
+MULTI_SELECT_COLOR_PAIR_NUMBER = 1
+COLORS = {
+    'COLOR_BLACK': curses.COLOR_BLACK,
+    'COLOR_BLUE': curses.COLOR_BLUE,
+    'COLOR_CYAN': curses.COLOR_CYAN,
+    'COLOR_GREEN': curses.COLOR_GREEN,
+    'COLOR_MAGENTA': curses.COLOR_MAGENTA,
+    'COLOR_RED': curses.COLOR_RED,
+    'COLOR_WHITE': curses.COLOR_WHITE,
+    'COLOR_YELLOW': curses.COLOR_YELLOW
+}
+
 class Picker(object):
     """The :class:`Picker <Picker>` object
 
@@ -19,9 +31,11 @@ class Picker(object):
     :param indicator: (optional) custom the selection indicator
     :param default_index: (optional) set this if the default selected option is not the first one
     :param options_map: (optional) a mapping function to pass each option through before displaying
+    :param multi_select_foreground_color: (optional) forground color of a selected option within multi_select mode
+    :param multi_select_background_color: (optional) background color of a selected option within multi_select mode
     """
 
-    def __init__(self, options, title=None, indicator='*', default_index=0, multi_select=False, min_selection_count=0, options_map=None):
+    def __init__(self, options, title=None, indicator='*', default_index=0, multi_select=False, min_selection_count=0, options_map=None, multi_select_foreground_color='COLOR_GREEN', multi_select_background_color='COLOR_WHITE'):
 
         if len(options) == 0:
             raise ValueError('options should not be an empty list')
@@ -43,6 +57,14 @@ class Picker(object):
         if options_map is not None and not callable(options_map):
             raise ValueError('options_map must be a callable function')
 
+        if multi_select_foreground_color and multi_select_foreground_color not in COLORS:
+            raise ValueError('multi_select_foreground_color must be one of: [\'{0}\']'.format('\', \''.join(list(COLORS))))
+
+        if multi_select_background_color and multi_select_background_color not in COLORS:
+            raise ValueError('multi_select_background_color must be one of: [\'{0}\']'.format('\', \''.join(list(COLORS))))
+
+        self.multi_select_foreground_color = COLORS[multi_select_foreground_color]
+        self.multi_select_background_color = COLORS[multi_select_background_color]
         self.index = default_index
         self.custom_handlers = {}
 
@@ -96,7 +118,7 @@ class Picker(object):
                 prefix = len(self.indicator) * ' '
 
             if self.multi_select and index in self.all_selected:
-                format = curses.color_pair(1)
+                format = curses.color_pair(MULTI_SELECT_COLOR_PAIR_NUMBER)
                 line = ('{0} {1}'.format(prefix, option), format)
             else:
                 line = '{0} {1}'.format(prefix, option)
@@ -165,8 +187,7 @@ class Picker(object):
         # hide the cursor
         curses.curs_set(0)
         #add some color for multi_select
-        #@todo make colors configurable
-        curses.init_pair(1, curses.COLOR_GREEN, curses.COLOR_WHITE)
+        curses.init_pair(MULTI_SELECT_COLOR_PAIR_NUMBER, self.multi_select_foreground_color, self.multi_select_background_color)
 
     def _start(self, screen):
         self.screen = screen
@@ -177,7 +198,7 @@ class Picker(object):
         return curses.wrapper(self._start)
 
 
-def pick(options, title=None, indicator='*', default_index=0, multi_select=False, min_selection_count=0, options_map=None):
+def pick(options, title=None, indicator='*', default_index=0, multi_select=False, min_selection_count=0, options_map=None, multi_select_foreground_color='COLOR_GREEN', multi_select_background_color='COLOR_WHITE'):
     """Construct and start a :class:`Picker <Picker>`.
 
     Usage::
@@ -187,5 +208,5 @@ def pick(options, title=None, indicator='*', default_index=0, multi_select=False
       >>> options = ['option1', 'option2', 'option3']
       >>> option, index = pick(options, title)
     """
-    picker = Picker(options, title, indicator, default_index, multi_select, min_selection_count, options_map)
+    picker = Picker(options, title, indicator, default_index, multi_select, min_selection_count, options_map, multi_select_foreground_color, multi_select_background_color)
     return picker.start()

--- a/pick/__init__.py
+++ b/pick/__init__.py
@@ -18,9 +18,10 @@ class Picker(object):
     :param multi_select: (optional) if true its possible to select multiple values by hitting SPACE, defaults to False
     :param indicator: (optional) custom the selection indicator
     :param default_index: (optional) set this if the default selected option is not the first one
+    :param options_map: (optional) a mapping function to pass each option through before displaying
     """
 
-    def __init__(self, options, title=None, indicator='*', default_index=0, multi_select=False, min_selection_count=0):
+    def __init__(self, options, title=None, indicator='*', default_index=0, multi_select=False, min_selection_count=0, options_map=None):
 
         if len(options) == 0:
             raise ValueError('options should not be an empty list')
@@ -30,6 +31,7 @@ class Picker(object):
         self.indicator = indicator
         self.multi_select = multi_select
         self.min_selection_count = min_selection_count
+        self.options_map = options_map
         self.all_selected = []
 
         if default_index >= len(options):
@@ -37,6 +39,9 @@ class Picker(object):
 
         if multi_select and min_selection_count > len(options):
             raise ValueError('min_selection_count is bigger than the available options, you will not be able to make any selection')
+
+        if options_map is not None and not callable(options_map):
+            raise ValueError('options_map must be a callable function')
 
         self.index = default_index
         self.custom_handlers = {}
@@ -81,6 +86,10 @@ class Picker(object):
     def get_option_lines(self):
         lines = []
         for index, option in enumerate(self.options):
+            # pass the option through the options map of one was passed in
+            if self.options_map:
+                option = self.options_map(option)
+
             if index == self.index:
                 prefix = self.indicator
             else:
@@ -168,7 +177,7 @@ class Picker(object):
         return curses.wrapper(self._start)
 
 
-def pick(options, title=None, indicator='*', default_index=0, multi_select=False, min_selection_count=0):
+def pick(options, title=None, indicator='*', default_index=0, multi_select=False, min_selection_count=0, options_map=None):
     """Construct and start a :class:`Picker <Picker>`.
 
     Usage::
@@ -178,5 +187,5 @@ def pick(options, title=None, indicator='*', default_index=0, multi_select=False
       >>> options = ['option1', 'option2', 'option3']
       >>> option, index = pick(options, title)
     """
-    picker = Picker(options, title, indicator, default_index, multi_select, min_selection_count)
+    picker = Picker(options, title, indicator, default_index, multi_select, min_selection_count, options_map)
     return picker.start()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def fread(fname):
 
 setup(
     name='pick',
-    version='0.6.4',
+    version='0.6.5',
     description='pick an option in the terminal with a simple GUI',
     long_description=fread('README.md'),
     keywords='terminal gui',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def fread(fname):
 
 setup(
     name='pick',
-    version='0.6.3',
+    version='0.6.4',
     description='pick an option in the terminal with a simple GUI',
     long_description=fread('README.md'),
     keywords='terminal gui',

--- a/tests/test_pick.py
+++ b/tests/test_pick.py
@@ -47,6 +47,17 @@ class TestPick(unittest.TestCase):
         picker.mark_index()
         assert picker.get_selected() == [('option1', 0), ('option2', 1)]
 
+    def test_options_map(self):
+        title = 'Please choose an option: '
+        options = [{'label': 'option1'}, {'label': 'option2'}, {'label': 'option3'}]
+
+        def get_label(option): return option.get('label')
+
+        picker = Picker(options, title, indicator='*', options_map=get_label)
+        lines, current_line = picker.get_lines()
+        assert lines == [title, '', '* option1', '  option2', '  option3']
+        assert picker.get_selected() == ({ 'label': 'option1' }, 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_pick.py
+++ b/tests/test_pick.py
@@ -58,6 +58,38 @@ class TestPick(unittest.TestCase):
         assert lines == [title, '', '* option1', '  option2', '  option3']
         assert picker.get_selected() == ({ 'label': 'option1' }, 0)
 
+    def test_multi_select_colors(self):
+        title = 'Please choose an option: '
+        options = ['option1', 'option2', 'option3']
+
+        # valid colors
+        picker_loaded = False
+        try:
+            picker = Picker(options, title, multi_select=True, min_selection_count=1, multi_select_foreground_color='COLOR_BLUE', multi_select_background_color='COLOR_MAGENTA')
+            picker_loaded = True
+        except:
+            picker_loaded = False
+        assert picker_loaded == True
+
+        # invalid foreground color
+        picker_loaded = False
+        try:
+            picker = Picker(options, title, multi_select=True, min_selection_count=1, multi_select_foreground_color='pantone 505')
+            picker_loaded = True
+        except ValueError:
+            picker_loaded = False
+        assert picker_loaded == False
+
+        # invalid background color
+        picker_loaded = False
+        try:
+            picker = Picker(options, title, multi_select=True, min_selection_count=1, multi_select_foreground_color='pantone 15-0343')
+            picker_loaded = True
+        except ValueError:
+            picker_loaded = False
+        assert picker_loaded == False
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Building off this pull request:
https://github.com/wong2/pick/pull/17

I have added the ability to specify color options for the foreground and background when selecting a multi-select option. I added a new test, updated the README, and further incremented the version number.

The color provided must be one of the predefined curses color options. 