### PR TITLE
Add type hints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ publish:
 
 .PHONY=test
 test:
+	poetry run mypy .
 	poetry run pytest
 
 .PHONY=clean

--- a/example/basic.py
+++ b/example/basic.py
@@ -2,5 +2,7 @@ from pick import pick
 
 title = 'Please choose your favorite programming language: '
 options = ['Java', 'JavaScript', 'Python', 'PHP', 'C++', 'Erlang', 'Haskell']
-option, index = pick(options, title, indicator='=>', default_index=2)
+selection = pick(options, title, indicator='=>', default_index=2)
+assert len(selection) == 1
+option, index = selection[0]
 print(option, index)

--- a/example/custom.py
+++ b/example/custom.py
@@ -1,5 +1,6 @@
 import curses
 from pick import Picker
+from typing import Tuple
 
 def go_back(picker):
     return (None, -1)
@@ -7,7 +8,7 @@ def go_back(picker):
 title = 'Please choose your favorite programming language: '
 options = ['Java', 'JavaScript', 'Python', 'PHP', 'C++', 'Erlang', 'Haskell']
 
-picker = Picker(options, title)
+picker: Picker[Tuple[None, int]] = Picker(options, title)
 picker.register_custom_handler(curses.KEY_LEFT, go_back)
 option, index = picker.start()
 print(option, index)

--- a/example/custom.py
+++ b/example/custom.py
@@ -2,6 +2,16 @@ import curses
 from pick import Picker
 from typing import Tuple
 
+
+def print_selection(selection):
+    if isinstance(selection, list):
+        assert len(selection) == 1
+        option, index = selection[0]
+        print(option, index)
+    else:
+        print("KEY_LEFT pressed!")
+
+
 def go_back(picker):
     return (None, -1)
 
@@ -11,11 +21,11 @@ options = ['Java', 'JavaScript', 'Python', 'PHP', 'C++', 'Erlang', 'Haskell']
 # with type annotation
 picker: Picker[Tuple[None, int], str] = Picker(options, title)
 picker.register_custom_handler(curses.KEY_LEFT, go_back)
-option, index = picker.start()
-print(option, index)
+selection = picker.start()
+print_selection(selection)
 
 # with type warning suppression
 unannotated_picker = Picker(options, title)  # type: ignore[var-annotated]
 unannotated_picker.register_custom_handler(curses.KEY_LEFT, go_back)
-option, index = unannotated_picker.start()
-print(option, index)
+selection = picker.start()
+print_selection(selection)

--- a/example/custom.py
+++ b/example/custom.py
@@ -8,7 +8,14 @@ def go_back(picker):
 title = 'Please choose your favorite programming language: '
 options = ['Java', 'JavaScript', 'Python', 'PHP', 'C++', 'Erlang', 'Haskell']
 
-picker: Picker[Tuple[None, int]] = Picker(options, title)
+# with type annotation
+picker: Picker[Tuple[None, int], str] = Picker(options, title)
 picker.register_custom_handler(curses.KEY_LEFT, go_back)
 option, index = picker.start()
+print(option, index)
+
+# with type warning suppression
+unannotated_picker = Picker(options, title)  # type: ignore[var-annotated]
+unannotated_picker.register_custom_handler(curses.KEY_LEFT, go_back)
+option, index = unannotated_picker.start()
 print(option, index)

--- a/example/options_map_func.py
+++ b/example/options_map_func.py
@@ -12,6 +12,8 @@ def get_description_for_display(option):
     # format the option data for display
     return '{0} (grow on {1})'.format(option.get('name'), option.get('grow_on'))
 
-option, index = pick(options, title, indicator='=>', options_map_func=get_description_for_display)
 
+selection = pick(options, title, indicator='=>', options_map_func=get_description_for_display)
+assert len(selection) == 1
+option, index = selection[0]
 print(option, index)

--- a/example/scroll.py
+++ b/example/scroll.py
@@ -2,5 +2,7 @@ from pick import pick
 
 title = 'Select:'
 options = ['foo.bar%s.baz' % x for x in range(1, 71)]
-option, index = pick(options, title)
+selection = pick(options, title)
+assert len(selection) == 1
+option, index = selection[0]
 print(option, index)

--- a/poetry.lock
+++ b/poetry.lock
@@ -62,6 +62,32 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "mypy"
+version = "0.910"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3,<0.5.0"
+toml = "*"
+typed-ast = {version = ">=1.4.0,<1.5.0", markers = "python_version < \"3.8\""}
+typing-extensions = ">=3.7.4"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<1.5.0)"]
+
+[[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
@@ -137,6 +163,14 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "typed-ast"
+version = "1.4.3"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "4.0.1"
 description = "Backported and Experimental Type Hints for Python 3.6+"
@@ -167,7 +201,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6"
-content-hash = "885830f73fda3ccad4f4d5c589ff3deabe730057f770f09edef4aba742dce748"
+content-hash = "e686211bcb2c0bcefd54d87c5fd19220c64c87c6ae7737ab45eabd7ca094f581"
 
 [metadata.files]
 atomicwrites = [
@@ -194,6 +228,35 @@ iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
+mypy = [
+    {file = "mypy-0.910-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457"},
+    {file = "mypy-0.910-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb"},
+    {file = "mypy-0.910-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9"},
+    {file = "mypy-0.910-cp35-cp35m-win_amd64.whl", hash = "sha256:adaeee09bfde366d2c13fe6093a7df5df83c9a2ba98638c7d76b010694db760e"},
+    {file = "mypy-0.910-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:ecd2c3fe726758037234c93df7e98deb257fd15c24c9180dacf1ef829da5f921"},
+    {file = "mypy-0.910-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d9dd839eb0dc1bbe866a288ba3c1afc33a202015d2ad83b31e875b5905a079b6"},
+    {file = "mypy-0.910-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:3e382b29f8e0ccf19a2df2b29a167591245df90c0b5a2542249873b5c1d78212"},
+    {file = "mypy-0.910-cp36-cp36m-win_amd64.whl", hash = "sha256:53fd2eb27a8ee2892614370896956af2ff61254c275aaee4c230ae771cadd885"},
+    {file = "mypy-0.910-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b6fb13123aeef4a3abbcfd7e71773ff3ff1526a7d3dc538f3929a49b42be03f0"},
+    {file = "mypy-0.910-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e4dab234478e3bd3ce83bac4193b2ecd9cf94e720ddd95ce69840273bf44f6de"},
+    {file = "mypy-0.910-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:7df1ead20c81371ccd6091fa3e2878559b5c4d4caadaf1a484cf88d93ca06703"},
+    {file = "mypy-0.910-cp37-cp37m-win_amd64.whl", hash = "sha256:0aadfb2d3935988ec3815952e44058a3100499f5be5b28c34ac9d79f002a4a9a"},
+    {file = "mypy-0.910-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ec4e0cd079db280b6bdabdc807047ff3e199f334050db5cbb91ba3e959a67504"},
+    {file = "mypy-0.910-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:119bed3832d961f3a880787bf621634ba042cb8dc850a7429f643508eeac97b9"},
+    {file = "mypy-0.910-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:866c41f28cee548475f146aa4d39a51cf3b6a84246969f3759cb3e9c742fc072"},
+    {file = "mypy-0.910-cp38-cp38-win_amd64.whl", hash = "sha256:ceb6e0a6e27fb364fb3853389607cf7eb3a126ad335790fa1e14ed02fba50811"},
+    {file = "mypy-0.910-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1a85e280d4d217150ce8cb1a6dddffd14e753a4e0c3cf90baabb32cefa41b59e"},
+    {file = "mypy-0.910-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:42c266ced41b65ed40a282c575705325fa7991af370036d3f134518336636f5b"},
+    {file = "mypy-0.910-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:3c4b8ca36877fc75339253721f69603a9c7fdb5d4d5a95a1a1b899d8b86a4de2"},
+    {file = "mypy-0.910-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:c0df2d30ed496a08de5daed2a9ea807d07c21ae0ab23acf541ab88c24b26ab97"},
+    {file = "mypy-0.910-cp39-cp39-win_amd64.whl", hash = "sha256:c6c2602dffb74867498f86e6129fd52a2770c48b7cd3ece77ada4fa38f94eba8"},
+    {file = "mypy-0.910-py3-none-any.whl", hash = "sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d"},
+    {file = "mypy-0.910.tar.gz", hash = "sha256:704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
@@ -217,6 +280,38 @@ pytest = [
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+typed-ast = [
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-win32.whl", hash = "sha256:dde816ca9dac1d9c01dd504ea5967821606f02e510438120091b84e852367428"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-win_amd64.whl", hash = "sha256:777a26c84bea6cd934422ac2e3b78863a37017618b6e5c08f92ef69853e765d3"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:52b1eb8c83f178ab787f3a4283f68258525f8d70f778a2f6dd54d3b5e5fb4341"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c190f0899e9f9f8b6b7863debfb739abcb21a5c054f911ca3596d12b8a4c4c7f"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-win32.whl", hash = "sha256:398e44cd480f4d2b7ee8d98385ca104e35c81525dd98c519acff1b79bdaac363"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-win_amd64.whl", hash = "sha256:bff6ad71c81b3bba8fa35f0f1921fb24ff4476235a6e94a26ada2e54370e6da7"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:760ad187b1041a154f0e4d0f6aae3e40fdb51d6de16e5c99aedadd9246450e9e"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5feca99c17af94057417d744607b82dd0a664fd5e4ca98061480fd8b14b18d04"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:95431a26309a21874005845c21118c83991c63ea800dd44843e42a916aec5899"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-win32.whl", hash = "sha256:aee0c1256be6c07bd3e1263ff920c325b59849dc95392a05f258bb9b259cf39c"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9ad2c92ec681e02baf81fdfa056fe0d818645efa9af1f1cd5fd6f1bd2bdfd805"},
+    {file = "typed_ast-1.4.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b36b4f3920103a25e1d5d024d155c504080959582b928e91cb608a65c3a49e1a"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7538e495704e2ccda9b234b82423a4038f324f3a10c43bc088a1636180f11a41"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:af3d4a73793725138d6b334d9d247ce7e5f084d96284ed23f22ee626a7b88e39"},
+    {file = "typed_ast-1.4.3-cp38-cp38-win32.whl", hash = "sha256:f2362f3cb0f3172c42938946dbc5b7843c2a28aec307c49100c8b38764eb6927"},
+    {file = "typed_ast-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:dd4a21253f42b8d2b48410cb31fe501d32f8b9fbeb1f55063ad102fe9c425e40"},
+    {file = "typed_ast-1.4.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f328adcfebed9f11301eaedfa48e15bdece9b519fb27e6a8c01aa52a17ec31b3"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:2c726c276d09fc5c414693a2de063f521052d9ea7c240ce553316f70656c84d4"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:cae53c389825d3b46fb37538441f75d6aecc4174f615d048321b716df2757fb0"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b9574c6f03f685070d859e75c7f9eeca02d6933273b5e69572e5ff9d5e3931c3"},
+    {file = "typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
+    {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
+    {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dataclasses = { version = "^0.8", python = "~3.6" }
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"
+mypy = "^0.910"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[mypy]
+check_untyped_defs = True
+warn_return_any = True
+warn_unreachable = True
+warn_unused_ignores = True

--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -225,7 +225,7 @@ def pick(
     default_index: int = 0,
     multiselect: bool = False,
     min_selection_count: int = 0,
-    options_map_func: Optional[Callable[[OPTIONS_MAP_VALUE_T], str]] = None,
+    options_map_func: Optional[Callable[[OPTIONS_MAP_VALUE_T], Optional[str]]] = None,
 ) -> Union[
     List[SELECTION_T],
     List[Tuple[OPTIONS_MAP_VALUE_T, int]],

--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -34,7 +34,7 @@ class Picker(Generic[CUSTOM_HANDLER_RETURN_T, OPTIONS_MAP_VALUE_T]):
     default_index: int = 0
     multiselect: bool = False
     min_selection_count: int = 0
-    options_map_func: Optional[Callable[[OPTIONS_MAP_VALUE_T], str]] = None
+    options_map_func: Optional[Callable[[OPTIONS_MAP_VALUE_T], Optional[str]]] = None
     all_selected: List[int] = field(init=False, default_factory=list)
     custom_handlers: Dict[KEY_T, Callable[["Picker"], CUSTOM_HANDLER_RETURN_T]] = field(
         init=False, default_factory=dict

--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -84,8 +84,6 @@ class Picker(Generic[CUSTOM_HANDLER_RETURN_T, OPTIONS_MAP_VALUE_T]):
     def get_selected(
         self
     ) -> Union[
-        Tuple[str, int],
-        Tuple[OPTIONS_MAP_VALUE_T, int],
         List[Tuple[str, int]],
         List[Tuple[OPTIONS_MAP_VALUE_T, int]]
     ]:
@@ -98,7 +96,8 @@ class Picker(Generic[CUSTOM_HANDLER_RETURN_T, OPTIONS_MAP_VALUE_T]):
                 return_tuples.append((self.options[selected], selected))
             return return_tuples  # type: ignore[return-value]
         else:
-            return self.options[self.index], self.index  # type: ignore[return-value]
+            selection = self.options[self.index], self.index
+            return [selection]  # type: ignore[return-value]
 
     def get_title_lines(self) -> List[str]:
         if self.title:
@@ -164,8 +163,6 @@ class Picker(Generic[CUSTOM_HANDLER_RETURN_T, OPTIONS_MAP_VALUE_T]):
     def run_loop(
             self, screen
     ) -> Union[
-        SELECTION_T,
-        Tuple[OPTIONS_MAP_VALUE_T, int],
         List[SELECTION_T],
         List[Tuple[OPTIONS_MAP_VALUE_T, int]],
         CUSTOM_HANDLER_RETURN_T
@@ -204,8 +201,6 @@ class Picker(Generic[CUSTOM_HANDLER_RETURN_T, OPTIONS_MAP_VALUE_T]):
     def _start(
         self, screen
     ) -> Union[
-        SELECTION_T,
-        Tuple[OPTIONS_MAP_VALUE_T, int],
         List[SELECTION_T],
         List[Tuple[OPTIONS_MAP_VALUE_T, int]],
         CUSTOM_HANDLER_RETURN_T,
@@ -216,8 +211,6 @@ class Picker(Generic[CUSTOM_HANDLER_RETURN_T, OPTIONS_MAP_VALUE_T]):
     def start(
         self
     ) -> Union[
-        SELECTION_T,
-        Tuple[OPTIONS_MAP_VALUE_T, int],
         List[SELECTION_T],
         List[Tuple[OPTIONS_MAP_VALUE_T, int]],
         CUSTOM_HANDLER_RETURN_T,
@@ -234,8 +227,6 @@ def pick(
     min_selection_count: int = 0,
     options_map_func: Optional[Callable[[OPTIONS_MAP_VALUE_T], str]] = None,
 ) -> Union[
-    SELECTION_T,
-    Tuple[OPTIONS_MAP_VALUE_T, int],
     List[SELECTION_T],
     List[Tuple[OPTIONS_MAP_VALUE_T, int]],
     CUSTOM_HANDLER_RETURN_T,

--- a/tests/test_pick.py
+++ b/tests/test_pick.py
@@ -1,10 +1,12 @@
+from typing import Dict, Optional
+
 from pick import Picker
 
 
 def test_move_up_down():
     title = "Please choose an option: "
     options = ["option1", "option2", "option3"]
-    picker = Picker(options, title)
+    picker: Picker[str, str] = Picker(options, title)
     picker.move_up()
     assert picker.get_selected() == ("option3", 2)
     picker.move_down()
@@ -15,14 +17,14 @@ def test_move_up_down():
 def test_default_index():
     title = "Please choose an option: "
     options = ["option1", "option2", "option3"]
-    picker = Picker(options, title, default_index=1)
+    picker: Picker[str, str] = Picker(options, title, default_index=1)
     assert picker.get_selected() == ("option2", 1)
 
 
 def test_get_lines():
     title = "Please choose an option: "
     options = ["option1", "option2", "option3"]
-    picker = Picker(options, title, indicator="*")
+    picker: Picker[str, str] = Picker(options, title, indicator="*")
     lines, current_line = picker.get_lines()
     assert lines == [title, "", "* option1", "  option2", "  option3"]
     assert current_line == 3
@@ -30,7 +32,7 @@ def test_get_lines():
 
 def test_no_title():
     options = ["option1", "option2", "option3"]
-    picker = Picker(options)
+    picker: Picker[str, str] = Picker(options)
     lines, current_line = picker.get_lines()
     assert current_line == 1
 
@@ -38,7 +40,7 @@ def test_no_title():
 def test_multi_select():
     title = "Please choose an option: "
     options = ["option1", "option2", "option3"]
-    picker = Picker(options, title, multiselect=True, min_selection_count=1)
+    picker: Picker[str, str] = Picker(options, title, multiselect=True, min_selection_count=1)
     assert picker.get_selected() == []
     picker.mark_index()
     assert picker.get_selected() == [("option1", 0)]
@@ -51,10 +53,10 @@ def test_options_map_func():
     title = "Please choose an option: "
     options = [{"label": "option1"}, {"label": "option2"}, {"label": "option3"}]
 
-    def get_label(option):
+    def get_label(option: Dict[str, str]) -> Optional[str]:
         return option.get("label")
 
-    picker = Picker(options, title, indicator="*", options_map_func=get_label)
+    picker: Picker[str, Dict[str, str]] = Picker(options, title, indicator="*", options_map_func=get_label)
     lines, current_line = picker.get_lines()
     assert lines == [title, "", "* option1", "  option2", "  option3"]
     assert picker.get_selected() == ({"label": "option1"}, 0)

--- a/tests/test_pick.py
+++ b/tests/test_pick.py
@@ -8,17 +8,17 @@ def test_move_up_down():
     options = ["option1", "option2", "option3"]
     picker: Picker[str, str] = Picker(options, title)
     picker.move_up()
-    assert picker.get_selected() == ("option3", 2)
+    assert picker.get_selected() == [("option3", 2)]
     picker.move_down()
     picker.move_down()
-    assert picker.get_selected() == ("option2", 1)
+    assert picker.get_selected() == [("option2", 1)]
 
 
 def test_default_index():
     title = "Please choose an option: "
     options = ["option1", "option2", "option3"]
     picker: Picker[str, str] = Picker(options, title, default_index=1)
-    assert picker.get_selected() == ("option2", 1)
+    assert picker.get_selected() == [("option2", 1)]
 
 
 def test_get_lines():
@@ -59,4 +59,4 @@ def test_options_map_func():
     picker: Picker[str, Dict[str, str]] = Picker(options, title, indicator="*", options_map_func=get_label)
     lines, current_line = picker.get_lines()
     assert lines == [title, "", "* option1", "  option2", "  option3"]
-    assert picker.get_selected() == ({"label": "option1"}, 0)
+    assert picker.get_selected() == [({"label": "option1"}, 0)]


### PR DESCRIPTION
As announced in #52 this pull request adds type hints. It changes how certain functions have to be used, so it requires an increment of the major version, according to SemVer.

By adding type hints I made the existing complexity of `pick` explicit. I managed to simplify things by two changes:
1. Always return a list of picks, except when a custom handler is used.
2. Use a default `options_map_func` to get rid of a default type.

I adapted the tests and examples. I make use of my fork of `pick` in another project, [mtv-cli](https://github.com/MaxG87/mtv_cli/issues). There it helped me to get rid of some type warnings, but it is not yet _extensive use_ or _battle tested_ or something.