### PR TITLE
Change list to sequence for Picker.options

### DIFF
--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -1,6 +1,6 @@
 import curses
 from dataclasses import dataclass, field
-from typing import Generic, Callable, List, Optional, Dict, Union, Tuple, TypeVar
+from typing import Generic, Callable, List, Optional, Dict, Union, Tuple, TypeVar, Sequence
 
 __all__ = ["Picker", "pick"]
 
@@ -20,7 +20,7 @@ PICK_RETURN_T = Tuple[OPTIONS_MAP_VALUE_T, int]
 class Picker(Generic[CUSTOM_HANDLER_RETURN_T, OPTIONS_MAP_VALUE_T]):
     """The :class:`Picker <Picker>` object
 
-    :param options: a list of options to choose from
+    :param options: a sequence of options to choose from
     :param title: (optional) a title above options list
     :param multiselect: (optional) if true its possible to select multiple values by hitting SPACE, defaults to False
     :param indicator: (optional) custom the selection indicator
@@ -28,7 +28,7 @@ class Picker(Generic[CUSTOM_HANDLER_RETURN_T, OPTIONS_MAP_VALUE_T]):
     :param options_map_func: (optional) a mapping function to pass each option through before displaying
     """
 
-    options: List[OPTIONS_MAP_VALUE_T]
+    options: Sequence[OPTIONS_MAP_VALUE_T]
     title: Optional[str] = None
     indicator: str = "*"
     default_index: int = 0
@@ -202,7 +202,7 @@ class Picker(Generic[CUSTOM_HANDLER_RETURN_T, OPTIONS_MAP_VALUE_T]):
 
 
 def pick(
-    options: List[OPTIONS_MAP_VALUE_T],
+    options: Sequence[OPTIONS_MAP_VALUE_T],
     title: Optional[str] = None,
     indicator: str = "*",
     default_index: int = 0,


### PR DESCRIPTION
I was using pick for a personal project and I had a tuple of items that I wanted to pass to the `options` parameter of the `pick` function, but my type checker started throwing errors that I could not pass a tuple to a parameter of type `list`. This is just a simple fix so that any type that supports `len` and `getitem` can be passed.