### PR TITLE
Add option to pass in existing screen.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ interactive selection list in the terminal.
   multiple items by hitting SPACE
 - `min_selection_count`: (optional) for multi select feature to
   dictate a minimum of selected items before continuing
+- `stdscr`: (optional), if you are using `pick` within an existing curses application set this to your existing `stdscr` object.  It is assumed this has initialised in the standard way (e.g. via `curses.wrapper()`, or `curses.noecho(); curses.cbreak(); stdscr.kepad(True)`)
 
 ## Community Projects
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ interactive selection list in the terminal.
   multiple items by hitting SPACE
 - `min_selection_count`: (optional) for multi select feature to
   dictate a minimum of selected items before continuing
-- `stdscr`: (optional), if you are using `pick` within an existing curses application set this to your existing `stdscr` object.  It is assumed this has initialised in the standard way (e.g. via `curses.wrapper()`, or `curses.noecho(); curses.cbreak(); stdscr.kepad(True)`)
+- `screen`: (optional), if you are using `pick` within an existing curses application set this to your existing `screen` object.  It is assumed this has initialised in the standard way (e.g. via `curses.wrapper()`, or `curses.noecho(); curses.cbreak(); screen.kepad(True)`)
 
 ## Community Projects
 

--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -185,7 +185,7 @@ def pick(
     default_index: int = 0,
     multiselect: bool = False,
     min_selection_count: int = 0,
-    stdscr: Optional[curses.window] = None
+    screen: Optional[curses.window] = None
 ):
     picker: Picker = Picker(
         options,
@@ -194,6 +194,6 @@ def pick(
         default_index,
         multiselect,
         min_selection_count,
-        screen=stdscr
+        screen
     )
     return picker.start()

--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -33,7 +33,7 @@ class Picker(Generic[OPTION_T]):
     min_selection_count: int = 0
     selected_indexes: List[int] = field(init=False, default_factory=list)
     index: int = field(init=False, default=0)
-    screen: Optional[Any] = None  # curses._CursesWindow
+    screen: Optional[curses.window] = None
 
     def __post_init__(self) -> None:
         if len(self.options) == 0:
@@ -185,7 +185,7 @@ def pick(
     default_index: int = 0,
     multiselect: bool = False,
     min_selection_count: int = 0,
-    stdscr: Optional[Any] = None  # curses._CursesWindow
+    stdscr: Optional[curses.window] = None
 ):
     picker: Picker = Picker(
         options,

--- a/src/pick/__init__.py
+++ b/src/pick/__init__.py
@@ -33,6 +33,7 @@ class Picker(Generic[OPTION_T]):
     min_selection_count: int = 0
     selected_indexes: List[int] = field(init=False, default_factory=list)
     index: int = field(init=False, default=0)
+    screen: Optional[Any] = None  # curses._CursesWindow
 
     def __post_init__(self) -> None:
         if len(self.options) == 0:
@@ -166,6 +167,14 @@ class Picker(Generic[OPTION_T]):
         return self.run_loop(screen)
 
     def start(self):
+        if self.screen:
+            # Given an existing screen
+            # don't make any lasting changes
+            last_cur = curses.curs_set(0)
+            ret = self.run_loop(self.screen)
+            if last_cur:
+                curses.curs_set(last_cur)
+            return ret
         return curses.wrapper(self._start)
 
 
@@ -176,6 +185,7 @@ def pick(
     default_index: int = 0,
     multiselect: bool = False,
     min_selection_count: int = 0,
+    stdscr: Optional[Any] = None  # curses._CursesWindow
 ):
     picker: Picker = Picker(
         options,
@@ -184,5 +194,6 @@ def pick(
         default_index,
         multiselect,
         min_selection_count,
+        screen=stdscr
     )
     return picker.start()


### PR DESCRIPTION
I believe this fixes issue #91

adds optional stdscr parameter to pick() and if set takes a modified code path that skips normal initialisation but instead just hides (and unhides) the cursor.

This works for my test harness and running pytest still passes (as it should as won't touch this code path).

I've not caught the case where the user passes a bad paramter, or they haven't enabled things like cbreak.